### PR TITLE
Set $exclusiveMinimum and $exclusiveMaximum default false

### DIFF
--- a/src/IntegerValidator.php
+++ b/src/IntegerValidator.php
@@ -50,8 +50,8 @@ class IntegerValidator extends \Phramework\Validate\NumberValidator
     public function __construct(
         ?int $minimum = null,
         ?int $maximum = null,
-        bool $exclusiveMinimum = null,
-        bool $exclusiveMaximum = null,
+        ?bool $exclusiveMinimum = false,
+        ?bool $exclusiveMaximum = false,
         int $multipleOf = 1
     ) {
         if ($multipleOf !== null && $multipleOf <= 0) {

--- a/src/NumberValidator.php
+++ b/src/NumberValidator.php
@@ -53,13 +53,15 @@ class NumberValidator extends \Phramework\Validate\BaseValidator
     protected static $type = 'number';
 
     /**
+     * @param bool|null $exclusiveMinimum When null will behave as false
+     * @param bool|null $exclusiveMaximum When null will behave as false
      * @throws \DomainException When minimum is not less than the maximum
      */
     public function __construct(
         ?float $minimum = null,
         ?float $maximum = null,
-        ?bool $exclusiveMinimum = null,
-        ?bool $exclusiveMaximum = null,
+        ?bool $exclusiveMinimum = false,
+        ?bool $exclusiveMaximum = false,
         ?float $multipleOf = null
     ) {
         parent::__construct();
@@ -70,6 +72,14 @@ class NumberValidator extends \Phramework\Validate\BaseValidator
 
         if ($multipleOf !== null && $multipleOf <= 0) {
             throw new \InvalidArgumentException('multipleOf must be a positive number');
+        }
+
+        if ($exclusiveMinimum && $minimum === null) {
+            throw new \DomainException('If "exclusiveMinimum" is set to true, "minimum" MUST also be set');
+        }
+
+        if ($exclusiveMaximum && $maximum === null) {
+            throw new \DomainException('If "exclusiveMaximum" is set to true, "maximum" MUST also be set');
         }
 
         $this->minimum = $minimum;

--- a/src/UnsignedIntegerValidator.php
+++ b/src/UnsignedIntegerValidator.php
@@ -16,9 +16,6 @@
  */
 namespace Phramework\Validate;
 
-use Phramework\Validate\Result\Result;
-use \Phramework\Exceptions\IncorrectParametersException;
-
 /**
  * UnsignedInteger validator
  * @uses \Phramework\Validate\Integer As base implementation's rules to
@@ -49,8 +46,8 @@ class UnsignedIntegerValidator extends \Phramework\Validate\IntegerValidator
     public function __construct(
         int $minimum = 0,
         ?int $maximum = null,
-        bool $exclusiveMinimum = null,
-        bool $exclusiveMaximum = null,
+        ?bool $exclusiveMinimum = false,
+        ?bool $exclusiveMaximum = false,
         ?int $multipleOf = 1
     ) {
         if ($minimum < 0) {

--- a/tests/src/NumberValidatorTest.php
+++ b/tests/src/NumberValidatorTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class NumberValidatorTest extends TestCase
 {
-
     /**
      * @var NumberValidator
      */
@@ -69,7 +68,7 @@ class NumberValidatorTest extends TestCase
     }
 
     /**
-          * @dataProvider validateSuccessProvider
+     * @dataProvider validateSuccessProvider
      */
     public function testCreateFromJSON($input, $expected)
     {
@@ -82,12 +81,21 @@ class NumberValidatorTest extends TestCase
             "x-extra": "not existing"
         }';
 
+        /** @var NumberValidator $validatorObject */
         $validatorObject = NumberValidator::createFromJSON($json);
 
         $this->assertSame(
             'my number',
             $validatorObject->title,
             'Title must be passed'
+        );
+
+        $this->assertFalse(
+            $validatorObject->exclusiveMaximum
+        );
+
+        $this->assertFalse(
+            $validatorObject->exclusiveMinimum
         );
 
         $this->assertSame(
@@ -194,6 +202,32 @@ class NumberValidatorTest extends TestCase
             null,
             null,
             -1
+        );
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testAllowExclusiveMaximumOnlyIfMaximumIsSet()
+    {
+        new NumberValidator(
+            null,
+            null,
+            null,
+            true
+        );
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testAllowExclusiveMinimumOnlyIfMinimumIsSet()
+    {
+        new NumberValidator(
+            null,
+            null,
+            true,
+            false
         );
     }
 }


### PR DESCRIPTION
From draft v4

```
5.1.2.  maximum and exclusiveMaximum

5.1.2.1.  Valid values

   The value of "maximum" MUST be a JSON number.  The value of
   "exclusiveMaximum" MUST be a boolean.

   If "exclusiveMaximum" is present, "maximum" MUST also be present.

5.1.2.2.  Conditions for successful validation

   Successful validation depends on the presence and value of
   "exclusiveMaximum":

      if "exclusiveMaximum" is not present, or has boolean value false,
      then the instance is valid if it is lower than, or equal to, the
      value of "maximum";

      if "exclusiveMaximum" has boolean value true, the instance is
      valid if it is strictly lower than the value of "maximum".

5.1.2.3.  Default value

   "exclusiveMaximum", if absent, may be considered as being present
   with boolean value false.
```

Though in draft v7 exclusiveMaximum is defined as number instead of boolean
See https://json-schema.org/understanding-json-schema/reference/numeric.html#range

Maybe we should support both?